### PR TITLE
fix: return 1 for gcd_for_slice if all elements are 0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "weighted_rand"
-version = "0.3.2"
+version = "0.4.1"
 dependencies = [
  "criterion",
  "rand",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "weighted_rand"
-version = "0.4.1"
+version = "0.3.2"
 dependencies = [
  "criterion",
  "rand",

--- a/src/util.rs
+++ b/src/util.rs
@@ -14,13 +14,8 @@ pub mod math {
             return 0;
         }
 
-        let mut iter = slice.iter().skip_while(|x| x == &&0);
-        let first = match iter.next() {
-            Some(v) => *v,
-            None => return 1
-        };
-
-        let gcd = iter.fold(
+        let first = slice[0];
+        let gcd = slice.iter().fold(
             first,
             |acc, cur| {
                 if *cur == 0 {
@@ -30,7 +25,11 @@ pub mod math {
                 }
             },
         );
-        gcd
+        if gcd == 0 {
+            1
+        } else {
+            gcd
+        }
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -15,7 +15,7 @@ pub mod math {
         }
 
         let first = slice[0];
-        slice.iter().fold(
+        let gcd = slice.iter().fold(
             first,
             |acc, cur| {
                 if *cur == 0 {
@@ -24,7 +24,12 @@ pub mod math {
                     gcd(*cur, acc)
                 }
             },
-        )
+        );
+        if gcd == 0 {
+            1
+        } else {
+            gcd
+        }
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -15,7 +15,13 @@ pub mod math {
         }
 
         let first = slice[0];
-        let gcd = slice.iter().fold(
+        let mut iter = slice.iter().skip_while(|x| x == &&0);
+        let first = match iter.next() {
+            Some(v) => *v,
+            None => return 1
+        };
+
+        let gcd = iter.fold(
             first,
             |acc, cur| {
                 if *cur == 0 {
@@ -25,11 +31,7 @@ pub mod math {
                 }
             },
         );
-        if gcd == 0 {
-            1
-        } else {
-            gcd
-        }
+        gcd
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -14,8 +14,13 @@ pub mod math {
             return 0;
         }
 
-        let first = slice[0];
-        let gcd = slice.iter().fold(
+        let mut iter = slice.iter().skip_while(|x| x == &&0);
+        let first = match iter.next() {
+            Some(v) => *v,
+            None => return 1
+        };
+
+        let gcd = iter.fold(
             first,
             |acc, cur| {
                 if *cur == 0 {
@@ -25,11 +30,7 @@ pub mod math {
                 }
             },
         );
-        if gcd == 0 {
-            1
-        } else {
-            gcd
-        }
+        gcd
     }
 }
 


### PR DESCRIPTION
For `WalkerTableBuilder` if we call `build` and the sum of elements is 0 - it returns *"WalkerTable that performs unweighted random sampling"*
![image](https://github.com/ichi-h/weighted_rand/assets/39347109/f4ceaf41-7718-4cf7-bf6b-7e305fea7937)


But during call of `new` for `WalkerTableBuilder` (f32) we have a division by gcd - it leads to `division by zero` errors because it returns 0 for slice of 0. We need to return 1 for gcd if all elements are 0, so we can get *"WalkerTable that performs unweighted random sampling"* from `build` call for `WalkerTableBuilder` (f32) where all elements are `0.0`
![image](https://github.com/ichi-h/weighted_rand/assets/39347109/dd4351e3-5465-4200-bf9b-d514153fcdf7)
